### PR TITLE
Embed PDF resume and remove contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,164 +398,12 @@
       <!-- Section Title -->
         <div class="container section-title" data-aos="fade-up">
           <h2>Resume</h2>
-          <p>Engineering Lead focused on productionizing GenAI: LLMs, RAG, and agentic workflows on Kubernetes. Strong in microservices, observability, and evaluation.</p>
         </div><!-- End Section Title -->
 
       <div class="container" data-aos="fade-up" data-aos-delay="100">
-
-        <div class="row gy-4">
-          <!-- Left column with summary and contact -->
-          <div class="col-lg-4">
-            <div class="resume-side" data-aos="fade-right" data-aos-delay="100">
-              <div class="profile-img mb-4">
-                <img src="assets/img/profile/profile-square-2.webp" alt="Profile" class="img-fluid rounded">
-              </div>
-
-                <h3>Professional Summary</h3>
-                <p>AI Lead at Nokia building a modular GenAI platform on private/on-prem Kubernetes. Architected microservices with observability-first design and enabled distributed LLM training across GPU nodes.</p>
-
-                <h3 class="mt-4">Contact Information</h3>
-                <ul class="contact-info list-unstyled">
-                  <li><i class="bi bi-geo-alt"></i> Espoo, Finland</li>
-                  <li><i class="bi bi-envelope"></i> ulhaqi12@gmail.com</li>
-                  <li><i class="bi bi-phone"></i> +358 45 1960065</li>
-                  <li><i class="bi bi-linkedin"></i> linkedin.com/in/ulhaqi12</li>
-                </ul>
-
-                <div class="skills-animation mt-4">
-                  <h3>Technical Skills</h3>
-                  <div class="skill-item">
-                    <div class="d-flex justify-content-between">
-                      <span>GenAI Platform Architecture</span>
-                      <span>90%</span>
-                    </div>
-                    <div class="progress">
-                      <div class="progress-bar" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100"></div>
-                    </div>
-                  </div>
-
-                  <div class="skill-item">
-                    <div class="d-flex justify-content-between">
-                      <span>Microservices &amp; Kubernetes</span>
-                      <span>85%</span>
-                    </div>
-                    <div class="progress">
-                      <div class="progress-bar" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100"></div>
-                    </div>
-                  </div>
-
-                  <div class="skill-item">
-                    <div class="d-flex justify-content-between">
-                      <span>MLOps &amp; Observability</span>
-                      <span>85%</span>
-                    </div>
-                    <div class="progress">
-                      <div class="progress-bar" role="progressbar" aria-valuenow="85" aria-valuemin="0" aria-valuemax="100"></div>
-                    </div>
-                  </div>
-
-                  <div class="skill-item">
-                    <div class="d-flex justify-content-between">
-                      <span>Team Leadership</span>
-                      <span>80%</span>
-                    </div>
-                    <div class="progress">
-                      <div class="progress-bar" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100"></div>
-                    </div>
-                  </div>
-                </div>
-            </div>
-          </div>
-
-          <!-- Right column with experience and education -->
-          <div class="col-lg-8 ps-4 ps-lg-5">
-            <!-- Experience Section -->
-              <div class="resume-section" data-aos="fade-up">
-                <h3><i class="bi bi-briefcase me-2"></i>Professional Experience</h3>
-
-                <div class="resume-item">
-                  <h4>AI Lead — Nokia</h4>
-                  <h5>05/2023 – Present | Espoo, Finland</h5>
-                  <ul>
-                    <li>Led end-to-end development of a modular GenAI platform (RAG, agentic workflows, distributed LLM training) on private, on-prem Kubernetes.</li>
-                    <li>Managed and mentored engineers; defined sprints and aligned milestones with AI strategy.</li>
-                    <li>Built observability-first microservices with Docker, Kubernetes, MLFlow, OpenTelemetry, Prometheus, Grafana, Jaeger, Fluentd.</li>
-                    <li>Enabled distributed LLM training across GPU nodes with K8s-native scheduling for large-scale experiments and fine-tuning.</li>
-                  </ul>
-                </div>
-
-                <div class="resume-item">
-                  <h4>Research Assistant — Åbo Akademi University</h4>
-                  <h5>08/2022 – 07/2023 | Turku, Finland</h5>
-                  <ul>
-                    <li>Curated and published a large-scale AIS dataset supporting maritime research in Finland.</li>
-                  </ul>
-                </div>
-
-                <div class="resume-item">
-                  <h4>Machine Learning Engineer — Arbisoft</h4>
-                  <h5>08/2020 – 08/2022 | Lahore, Pakistan</h5>
-                  <ul>
-                    <li>Built NLP tagging pipelines for travel reviews (e.g., KAYAK) improving SEO and discoverability.</li>
-                    <li>Implemented hotel-specific tag extraction (cleanliness, service) for personalized search.</li>
-                    <li>Evaluated open MT models to improve multilingual access to reviews.</li>
-                    <li>Delivered prototypes and communicated insights to clients.</li>
-                  </ul>
-                </div>
-              </div>
-
-              <!-- Education Section -->
-              <div class="resume-section" data-aos="fade-up" data-aos-delay="100">
-                <h3><i class="bi bi-mortarboard me-2"></i>Education</h3>
-
-                <div class="resume-item">
-                  <h4>EDISS (Åbo Akademi University)</h4>
-                  <h5>2022–2024</h5>
-                  <p class="company"><i class="bi bi-building"></i> Erasmus Mundus Joint Master’s</p>
-                </div>
-
-                <div class="resume-item">
-                  <h4>University of the Balearic Islands (UIB)</h4>
-                  <h5>2023–2024</h5>
-                  <p class="company"><i class="bi bi-building"></i> Master’s in Intelligent Systems (dual-degree track)</p>
-                </div>
-
-                <div class="resume-item">
-                  <h4>University of the Punjab</h4>
-                  <h5>2016–2020</h5>
-                  <p class="company"><i class="bi bi-building"></i> BS Computer Science</p>
-                </div>
-              </div>
-
-
-              <!-- Certifications Section -->
-              <div class="resume-section" data-aos="fade-up" data-aos-delay="200">
-                <h3><i class="bi bi-award me-2"></i>Certifications</h3>
-
-                <div class="resume-item">
-                  <h4>Deep Learning Specialization — DeepLearning.ai</h4>
-                </div>
-
-                <div class="resume-item">
-                  <h4>TensorFlow Developer Professional Certificate — DeepLearning.ai</h4>
-                </div>
-
-                <div class="resume-item">
-                  <h4>IBM Advanced Data Science Specialization</h4>
-                </div>
-
-                <div class="resume-item">
-                  <h4>AWS Fundamentals (Cloud-Native &amp; Serverless)</h4>
-                </div>
-
-                <div class="resume-item">
-                  <h4>SQL for Data Science</h4>
-                </div>
-              </div>
-
-          </div>
+        <div class="pdf-container" style="min-height: 800px;">
+          <iframe src="assets/cv.pdf" style="width:100%; height:100%;" frameborder="0"></iframe>
         </div>
-
       </div>
 
     </section><!-- /Resume Section -->
@@ -888,8 +736,8 @@
 
       <div class="container">
 
-        <div class="row g-4 g-lg-5">
-          <div class="col-lg-5">
+        <div class="row g-4 g-lg-5 justify-content-center">
+          <div class="col-lg-6">
               <div class="info-box">
                 <h3>Contact Info</h3>
                 <p>Let’s collaborate on production-ready GenAI systems.</p>
@@ -926,44 +774,6 @@
               </div>
           </div>
 
-          <div class="col-lg-7">
-            <div class="contact-form">
-              <h3>Get In Touch</h3>
-              <p>Let’s collaborate on production-ready GenAI systems.</p>
-
-              <form action="forms/contact.php" method="post" class="php-email-form">
-                <div class="row gy-4">
-
-                  <div class="col-md-6">
-                    <input type="text" name="name" class="form-control" placeholder="Your Name" required="">
-                  </div>
-
-                  <div class="col-md-6 ">
-                    <input type="email" class="form-control" name="email" placeholder="Your Email" required="">
-                  </div>
-
-                  <div class="col-12">
-                    <input type="text" class="form-control" name="subject" placeholder="Subject" required="">
-                  </div>
-
-                  <div class="col-12">
-                    <textarea class="form-control" name="message" rows="6" placeholder="Message" required=""></textarea>
-                  </div>
-
-                  <div class="col-12 text-center">
-                    <div class="loading">Loading</div>
-                    <div class="error-message"></div>
-                    <div class="sent-message">Your message has been sent. Thank you!</div>
-
-                    <button type="submit" class="btn">Send Message</button>
-                  </div>
-
-                </div>
-              </form>
-
-            </div>
-          </div>
-
         </div>
 
       </div>
@@ -997,7 +807,6 @@
 
   <!-- Vendor JS Files -->
   <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-  <script src="assets/vendor/php-email-form/validate.js"></script>
   <script src="assets/vendor/aos/aos.js"></script>
   <script src="assets/vendor/typed.js/typed.umd.js"></script>
   <script src="assets/vendor/purecounter/purecounter_vanilla.js"></script>


### PR DESCRIPTION
## Summary
- Replace detailed resume content with PDF viewer referencing `assets/cv.pdf`
- Remove message form from contact section, leaving only contact details

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a1e9dae408325b4da4545c066b53f